### PR TITLE
Fix Supabase login

### DIFF
--- a/components/auth-provider.tsx
+++ b/components/auth-provider.tsx
@@ -27,8 +27,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       } = await supabase.auth.getSession()
 
       if (session?.user?.id) {
-        const { data: userData } = await supabase.from("users").select("*").eq("id", session.user.id).single()
+        const { data: userData } = await supabase
+          .from("users")
+          .select("*")
+          .eq("id", session.user.id)
+          .single()
         if (userData) {
+          if (typeof window !== "undefined") {
+            localStorage.removeItem("user_session")
+          }
           setUser(userData as unknown as User)
           return
         }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -44,10 +44,9 @@ export async function signIn(email: string, password: string) {
   // Sign in with Supabase Auth using the user's credentials
   const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
     email,
-    password: "dummy_password", // We'll handle this differently
+    password,
   })
 
-  // If Supabase auth fails, create a manual session
   if (authError) {
     // Store user info in localStorage as a fallback
     if (typeof window !== "undefined") {
@@ -60,6 +59,9 @@ export async function signIn(email: string, password: string) {
         }),
       )
     }
+  } else if (typeof window !== "undefined") {
+    // Clean up any stale fallback session on successful Supabase sign in
+    localStorage.removeItem("user_session")
   }
 
   return result.user


### PR DESCRIPTION
## Summary
- sign in to Supabase using the provided password
- clear old fallback sessions when Supabase authentication succeeds
- drop fallback session when getting user data if Supabase session exists

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6877f470a1d8832fba8ac665499c4269