### PR TITLE
Add placeholder pages for user, owner, and admin

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+export default function AdminSettingsPage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Settings</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Application Settings</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-gray-500">This area is under construction.</p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/app/profile/page.tsx
+++ b/app/app/profile/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useAuth } from "@/components/auth-provider"
+
+export default function UserProfilePage() {
+  const { user } = useAuth()
+
+  if (!user) {
+    return null
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Profile</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Account Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div>
+            <span className="font-medium">Name:</span> {user.name}
+          </div>
+          <div>
+            <span className="font-medium">Email:</span> {user.email}
+          </div>
+          <div>
+            <span className="font-medium">Address:</span> {user.address}
+          </div>
+          <div>
+            <span className="font-medium">Role:</span> {user.role}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/app/ratings/page.tsx
+++ b/app/app/ratings/page.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Star, Calendar } from "lucide-react"
+import { supabase } from "@/lib/supabase"
+import type { Rating } from "@/lib/types"
+import { useAuth } from "@/components/auth-provider"
+import { useToast } from "@/hooks/use-toast"
+
+export default function UserRatingsPage() {
+  const [ratings, setRatings] = useState<Rating[]>([])
+  const [loading, setLoading] = useState(true)
+  const { user } = useAuth()
+  const { toast } = useToast()
+
+  useEffect(() => {
+    const fetchRatings = async () => {
+      try {
+        const { data, error } = await supabase
+          .from("ratings")
+          .select(`*, store:stores(name)`)
+          .eq("user_id", user?.id)
+          .order("created_at", { ascending: false })
+
+        if (error) throw error
+        setRatings(data || [])
+      } catch (error) {
+        console.error("Error fetching ratings:", error)
+        toast({
+          title: "Error",
+          description: "Failed to fetch ratings",
+          variant: "destructive",
+        })
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (user) {
+      fetchRatings()
+    }
+  }, [user])
+
+  const renderStars = (value: number) => (
+    <div className="flex space-x-1">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <Star
+          key={star}
+          className={`h-4 w-4 ${star <= value ? "text-yellow-400 fill-current" : "text-gray-300"}`}
+        />
+      ))}
+    </div>
+  )
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold">My Ratings</h1>
+        <div className="h-64 bg-gray-200 animate-pulse rounded" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">My Ratings</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Ratings</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Store</TableHead>
+                <TableHead>Rating</TableHead>
+                <TableHead>Date</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {ratings.map((rating) => (
+                <TableRow key={rating.id}>
+                  <TableCell className="font-medium">{rating.store?.name}</TableCell>
+                  <TableCell>
+                    <div className="flex items-center space-x-2">
+                      {renderStars(rating.value)}
+                      <span className="text-sm font-medium">{rating.value}</span>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center space-x-2">
+                      <Calendar className="h-4 w-4 text-gray-400" />
+                      <span className="text-sm">{new Date(rating.created_at).toLocaleDateString()}</span>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/owner/analytics/page.tsx
+++ b/app/owner/analytics/page.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { supabase } from "@/lib/supabase"
+import { useAuth } from "@/components/auth-provider"
+import { useToast } from "@/hooks/use-toast"
+import type { Rating, Store } from "@/lib/types"
+import { Star, Store as StoreIcon, Users } from "lucide-react"
+
+export default function OwnerAnalyticsPage() {
+  const [stores, setStores] = useState<Store[]>([])
+  const [ratings, setRatings] = useState<Rating[]>([])
+  const [loading, setLoading] = useState(true)
+  const { user } = useAuth()
+  const { toast } = useToast()
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const { data: ownedStores, error: storesError } = await supabase
+          .from("stores")
+          .select("*")
+          .eq("owner_id", user?.id)
+
+        if (storesError) throw storesError
+
+        const storeIds = ownedStores?.map((s) => s.id) || []
+
+        const { data: storeRatings, error: ratingsError } = await supabase
+          .from("ratings")
+          .select("*")
+          .in("store_id", storeIds)
+
+        if (ratingsError) throw ratingsError
+
+        setStores(ownedStores || [])
+        setRatings(storeRatings || [])
+      } catch (error) {
+        console.error("Error fetching analytics:", error)
+        toast({
+          title: "Error",
+          description: "Failed to fetch analytics",
+          variant: "destructive",
+        })
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (user) {
+      fetchData()
+    }
+  }, [user])
+
+  const totalStores = stores.length
+  const totalRatings = ratings.length
+  const avgRating =
+    ratings.reduce((sum, r) => sum + r.value, 0) / (ratings.length || 1)
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold">Analytics</h1>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-32 bg-gray-200 rounded animate-pulse" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Analytics</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total Stores</CardTitle>
+            <StoreIcon className="h-4 w-4 text-blue-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{totalStores}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total Ratings</CardTitle>
+            <Users className="h-4 w-4 text-green-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{totalRatings}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Average Rating</CardTitle>
+            <Star className="h-4 w-4 text-yellow-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{avgRating.toFixed(1)}</div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/owner/profile/page.tsx
+++ b/app/owner/profile/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useAuth } from "@/components/auth-provider"
+
+export default function OwnerProfilePage() {
+  const { user } = useAuth()
+
+  if (!user) {
+    return null
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Profile</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Account Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div>
+            <span className="font-medium">Name:</span> {user.name}
+          </div>
+          <div>
+            <span className="font-medium">Email:</span> {user.email}
+          </div>
+          <div>
+            <span className="font-medium">Address:</span> {user.address}
+          </div>
+          <div>
+            <span className="font-medium">Role:</span> {user.role}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `/app/ratings` page for users
- implement `/app/profile` page to display user account details
- implement `/admin/settings` placeholder page
- add analytics and profile pages for store owners

## Testing
- `npm run lint` *(fails interactive but handled)*

------
https://chatgpt.com/codex/tasks/task_e_6877f6c019a8832fa3e600f9119b88d7