### PR TITLE
Add secure stores API route

### DIFF
--- a/app/api/stores/route.ts
+++ b/app/api/stores/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase'
+
+export async function GET() {
+  const supabase = createServerClient()
+  const { data, error } = await supabase.from('stores').select('*')
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -30,10 +30,12 @@ export default function UserStoresPage() {
 
       if (ratingsError) throw ratingsError
 
-      // Get full store details
-      const { data: storeDetails, error: storesError } = await supabase.from("stores").select("*")
-
-      if (storesError) throw storesError
+      // Get full store details via server route to bypass RLS
+      const storeRes = await fetch("/api/stores")
+      if (!storeRes.ok) {
+        throw new Error("Failed to fetch stores")
+      }
+      const storeDetails: Store[] = await storeRes.json()
 
       // Get user's ratings
       const { data: userRatings, error: userRatingsError } = await supabase


### PR DESCRIPTION
## Summary
- add server route to retrieve stores using the service role
- fetch stores via `/api/stores` on the client side

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878233840ac832f970eace719b23cc0