### PR TITLE
Fix auth/session and rating flow

### DIFF
--- a/app/api/ratings/route.ts
+++ b/app/api/ratings/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabaseBrowser } from '@/lib/supabase-browser'
+import { supabaseAdmin } from '@/lib/supabase-admin'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { storeId, value } = await req.json()
+    if (!storeId || typeof value !== 'number') {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+    }
+
+    const authHeader = req.headers.get('authorization')
+    let userId: string | null = null
+
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.slice(7)
+      const { data: { user }, error } = await supabaseBrowser.auth.getUser(token)
+      if (error || !user) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+      userId = user.id
+    }
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: rating, error: rateErr } = await supabaseAdmin
+      .from('ratings')
+      .upsert({ user_id: userId, store_id: storeId, value }, { onConflict: 'user_id,store_id' })
+      .select()
+      .single()
+    if (rateErr) throw rateErr
+
+    const { data: avg } = await supabaseAdmin
+      .from('store_avg_ratings')
+      .select('*')
+      .eq('store_id', storeId)
+      .single()
+
+    return NextResponse.json({ rating, avg })
+  } catch (err: any) {
+    console.error('POST /api/ratings error', err)
+    return NextResponse.json({ error: err.message ?? 'Server error' }, { status: 500 })
+  }
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -85,17 +85,21 @@ export default function UserStoresPage() {
 
     setSubmitting(true)
     try {
-      const { error } = await supabase.from("ratings").upsert({
-        user_id: user.id,
-        store_id: selectedStore.id,
-        value: rating,
+      const session = await supabase.auth.getSession()
+      const token = session.data.session?.access_token
+      const res = await fetch('/api/ratings', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ storeId: selectedStore.id, value: rating }),
       })
-
-      if (error) throw error
+      if (!res.ok) throw new Error('Request failed')
 
       toast({
-        title: "Success",
-        description: "Rating submitted successfully",
+        title: 'Success',
+        description: 'Rating submitted successfully',
       })
 
       setSelectedStore(null)
@@ -212,9 +216,10 @@ export default function UserStoresPage() {
       </Card>
 
       <Dialog open={!!selectedStore} onOpenChange={() => setSelectedStore(null)}>
-        <DialogContent>
+        <DialogContent aria-describedby="rate-desc">
           <DialogHeader>
             <DialogTitle>Rate {selectedStore?.name}</DialogTitle>
+            <DialogDescription id="rate-desc">Select a rating from 1 to 5.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div>

--- a/components/auth-provider.tsx
+++ b/components/auth-provider.tsx
@@ -1,128 +1,36 @@
-"use client"
+'use client'
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { supabaseBrowser } from '@/lib/supabase-browser'
 
-import type React from "react"
-
-import { createContext, useContext, useEffect, useState } from "react"
-import type { User } from "@/lib/types"
-import { supabase } from "@/lib/supabase"
-
-interface AuthContextType {
-  user: User | null
+type AuthCtx = {
+  session: any | null
+  user: any | null
   loading: boolean
-  signOut: () => Promise<void>
-  refreshUser: () => Promise<void>
 }
+const Ctx = createContext<AuthCtx>({ session: null, user: null, loading: true })
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined)
-
-export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User | null>(null)
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<any | null>(null)
+  const [user, setUser] = useState<any | null>(null)
   const [loading, setLoading] = useState(true)
 
-  const refreshUser = async () => {
-    try {
-      // First try Supabase session
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
-
-      if (session?.user?.id) {
-        const { data: userData } = await supabase
-          .from("users")
-          .select("*")
-          .eq("id", session.user.id)
-          .single()
-        if (userData) {
-          if (typeof window !== "undefined") {
-            localStorage.removeItem("user_session")
-          }
-          setUser(userData as unknown as User)
-          return
-        }
-      }
-
-      // Fallback to localStorage
-      if (typeof window !== "undefined") {
-        const storedSession = localStorage.getItem("user_session")
-        if (storedSession) {
-          try {
-            const userData = JSON.parse(storedSession) as User
-            setUser(userData)
-            return
-          } catch {
-            localStorage.removeItem("user_session")
-          }
-        }
-      }
-
-      setUser(null)
-    } catch (error) {
-      console.error("Error fetching user:", error)
-      setUser(null)
-    }
-  }
-
   useEffect(() => {
-    refreshUser().finally(() => setLoading(false))
-
-    // Listen to Supabase auth changes
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange(async (event, session) => {
-      if (event === "SIGNED_OUT" || !session) {
-        setUser(null)
-        if (typeof window !== "undefined") {
-          localStorage.removeItem("user_session")
-        }
-      } else {
-        await refreshUser()
-      }
+    supabaseBrowser.auth.getSession().then(({ data }) => {
+      setSession(data.session)
+      setUser(data.session?.user ?? null)
       setLoading(false)
     })
-
-    // Listen to custom auth changes
-    const handleCustomAuthChange = (event: CustomEvent) => {
-      const { user: userData, event: authEvent } = event.detail
-      if (authEvent === "SIGNED_OUT") {
-        setUser(null)
-      } else if (authEvent === "SIGNED_IN" && userData) {
-        setUser(userData as User)
-      }
-      setLoading(false)
-    }
-
-    if (typeof window !== "undefined") {
-      window.addEventListener("auth_change", handleCustomAuthChange as EventListener)
-    }
-
-    return () => {
-      subscription.unsubscribe()
-      if (typeof window !== "undefined") {
-        window.removeEventListener("auth_change", handleCustomAuthChange as EventListener)
-      }
-    }
+    const { data: sub } = supabaseBrowser.auth.onAuthStateChange((_evt, sess) => {
+      setSession(sess)
+      setUser(sess?.user ?? null)
+    })
+    return () => { sub.subscription.unsubscribe() }
   }, [])
 
-  const signOut = async () => {
-    await supabase.auth.signOut()
-    if (typeof window !== "undefined") {
-      localStorage.removeItem("user_session")
-      window.dispatchEvent(
-        new CustomEvent("auth_change", {
-          detail: { user: null, event: "SIGNED_OUT" },
-        }),
-      )
-    }
-    setUser(null)
-  }
-
-  return <AuthContext.Provider value={{ user, loading, signOut, refreshUser }}>{children}</AuthContext.Provider>
+  return (
+    <Ctx.Provider value={{ session, user, loading }}>
+      {children}
+    </Ctx.Provider>
+  )
 }
-
-export function useAuth() {
-  const context = useContext(AuthContext)
-  if (context === undefined) {
-    throw new Error("useAuth must be used within an AuthProvider")
-  }
-  return context
-}
+export const useAuth = () => useContext(Ctx)

--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js'
+
+export const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false } }
+)

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js'
+
+export const supabaseBrowser = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      storageKey: 'srp-auth',
+    },
+  }
+)

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,19 +1,2 @@
-import { createClient } from "@supabase/supabase-js"
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-
-// Create a singleton client
-let supabaseInstance: ReturnType<typeof createClient> | null = null
-
-export const supabase = (() => {
-  if (!supabaseInstance) {
-    supabaseInstance = createClient(supabaseUrl, supabaseAnonKey)
-  }
-  return supabaseInstance
-})()
-
-// Server-side client for admin operations
-export const createServerClient = () => {
-  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
-}
+export { supabaseBrowser as supabase } from './supabase-browser'
+export { supabaseAdmin, supabaseAdmin as createServerClient } from './supabase-admin'

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,0 +1,34 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+const client = createClient(supabaseUrl, anon)
+
+async function run() {
+  const email = `smoke+${Date.now()}@example.com`
+  const password = 'testpass123'
+
+  // sign up
+  const { data: sign } = await client.auth.signUp({ email, password })
+  if (!sign.user) throw new Error('signUp failed')
+
+  // sign in
+  const { data: login } = await client.auth.signInWithPassword({ email, password })
+  if (!login.session) throw new Error('signIn failed')
+
+  const token = login.session.access_token
+  const storeRes = await client.from('stores').select('*').limit(1)
+  if (storeRes.error || !storeRes.data?.length) throw new Error('load stores failed')
+  const storeId = storeRes.data[0].id
+
+  const res = await fetch('http://localhost:3000/api/ratings', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ storeId, value: 4 }),
+  })
+  const json = await res.json()
+  console.log('rating response', res.status, json)
+}
+
+run().catch((e) => { console.error(e); process.exit(1) })


### PR DESCRIPTION
## Summary
- add browser and admin Supabase clients
- rework auth helpers to use Supabase Auth
- simplify auth provider for session persistence
- expose rating API using service role
- send rating to API from user page and add dialog description
- export new clients via `lib/supabase`
- add simple smoke script

## Testing
- `npm run lint` *(fails: prompts configuration)*
- `npm run build` *(fails: supabaseKey is required during build)*


------
https://chatgpt.com/codex/tasks/task_e_6878291bd640832faf2886608b52f2e6